### PR TITLE
Update cache_buster.module

### DIFF
--- a/cache_buster.module
+++ b/cache_buster.module
@@ -5,5 +5,5 @@
  * Remove Query Strings from CSS filenames (Cache Buster)
  */
 function cache_buster_process_html(&$variables) {
-  $variables['styles'] = preg_replace('/\.css\?.*"/','.css"', $variables['styles']);
+  $variables['styles'] = preg_replace('/\.css\?.*?"/','.css"', $variables['styles']);
 }


### PR DESCRIPTION
With "Adaptive Theme" this module screwed my media queries (which are added after the "src" parameters).
E.g. :
<link type="text/css" rel="stylesheet" href="responsive.layout.css?ns93yt" media="only screen">
Would become :
<link type="text/css" rel="stylesheet" href="responsive.layout.css">